### PR TITLE
Retry `cf api` to avoid flakes

### DIFF
--- a/concourse/enable_diego_docker_feature_flag
+++ b/concourse/enable_diego_docker_feature_flag
@@ -2,7 +2,17 @@
 
 set -e -x -u
 
-cf api --skip-ssl-validation $CF_TARGET
+
+for i in $(seq 10); do
+  echo "Attempt #${i}"
+
+  if cf api --skip-ssl-validation $CF_TARGET; then
+    break
+  fi
+
+  sleep 1
+done
+
 cf auth $CF_USER $CF_PASSWORD
 
 # list existing feature flags


### PR DESCRIPTION
Adding retry to `cf api` request to mitigate flakes in garden pipelines.

More details in: https://www.pivotaltracker.com/story/show/129349109

[#129349109]

Signed-off-by: Petar Petrov <pppepito86@gmail.com>