### PR TITLE
Prevent warp-drive jobs from accidentally running together

### DIFF
--- a/pipelines/diego-pipeline.yml
+++ b/pipelines/diego-pipeline.yml
@@ -101,7 +101,6 @@ jobs:
 - name: bbl-up-warp-drive
   serial_groups:
   - warp-drive-cf-deployment
-  - warp-drive-vizzini
   - warp-drive-cf-acceptance-tests
   public: true
   plan:
@@ -987,9 +986,8 @@ jobs:
       CONFIG_FILE_PATH: envs/warp-drive/integration_config.json
       SKIP_REGEXP: "Syslog drain"
 
-
 - name: warp-drive-run-wats
-  serial_groups: [warp-drive-vizzini]
+  serial_groups: [warp-drive-cf-deployment]
   plan:
   - get: candidate-lock
     passed: [warp-drive-deploy-cf-deployment,warp-drive-smoke-tests]


### PR DESCRIPTION
I noticed that warp-drive-run-wats was the only job in warp-drive-vizzini.  This could lead to the job running when other warp-drive jobs are running.