### PR TITLE
add docker creds to pull image from public registry

### DIFF
--- a/garden-runc-release/pipelines/garden-runc-release.yml
+++ b/garden-runc-release/pipelines/garden-runc-release.yml
@@ -1684,6 +1684,8 @@ jobs:
         WITH_BPM=false
         WITH_CONTAINERD_MODE=true
         WITH_CPU_THROTTLING=false
+        DOCKER_REGISTRY_USERNAME=((dockerhub-appruntimeplatform-username))
+        DOCKER_REGISTRY_PASSWORD=((dockerhub-appruntimeplatform-password))
       BBL_STATE_DIR: bbl-garden-env
   - task: run-gats-errand
     file: cf-deployment-concourse-tasks/run-errand/task.yml


### PR DESCRIPTION
Issue: https://ci.funtime.lol/teams/wg-arp-garden/pipelines/garden-runc-release/jobs/run-gats-with-containerd/builds/201.1

Configure the GATS task with Docker registry credentials to avoid Docker Hub rate limiting.

