### PR TITLE
Add MySQL 8.4 Dockerfile and CI pipeline image build job

### DIFF
--- a/shared/dockerfiles/metadata.yml
+++ b/shared/dockerfiles/metadata.yml
@@ -1,3 +1,7 @@
+# @AI-Generated
+# Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+# Description:
+# 2026-05-08: Add tas-runtime-mysql-8.4 entry (TNZ-99882)
 ---
 readme:
   This directory contains the shared dockerfiles
@@ -5,4 +9,5 @@ opsfiles:
   tas-runtime-build: Main image used for testing all tests in this repo that doesn't require a DB
   tas-runtime-postgres: Build upon tas-runtime-build with postgres
   tas-runtime-mysql-8.0: Build upon tas-runtime-build with mysql
+  tas-runtime-mysql-8.4: Build upon tas-runtime-build with mysql 8.4
   tas-runtime-mysql-5.7: Build from debian image with 5.7-debian tag

--- a/shared/dockerfiles/tas-runtime-mysql-8.4/Dockerfile
+++ b/shared/dockerfiles/tas-runtime-mysql-8.4/Dockerfile
@@ -1,0 +1,71 @@
+# @AI-Generated
+# Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+# Description:
+# 2026-05-08: Add MySQL 8.4 Dockerfile for CI image build (TNZ-99882)
+
+# Dockerfile name: mysql-8.4
+# should be located at cloudfoundry/tas-runtime-mysql-8.4
+###
+ARG BUILD_URI
+
+FROM ${BUILD_URI} AS build
+
+ARG MYSQL_MAJOR_VERSION
+# MYSQL_VERSION needs to come from https://github.com/docker-library/mysql/blob/master/versions.json ultimately
+ARG MYSQL_VERSION
+
+LABEL org.cloudfoundry.tas-runtime-mysql-8.4.dockerfile.url="https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/shared/dockerfiles/tas-runtime-mysql-8.4/Dockerfile"
+LABEL org.cloudfoundry.tas-runtime-mysql-8.4.notes.md="Build upon tas-runtime-build with mysql 8.4"
+
+### The following section is taken and modified from https://github.com/docker-library/mysql/ ###
+#
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg gosu dirmngr tzdata zstd && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+RUN set -eux; \
+	key='bca43417c3b485dd128ec6d4b7b3b788a8d3785c'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	mkdir -p /etc/apt/keyrings; \
+	gpg --batch --export "$key" > /etc/apt/keyrings/mysql.gpg; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"
+
+RUN export DISTRUBTION_CODENAME=$(cat /etc/lsb-release  | grep DISTRIB_CODENAME | cut -f 2 -d =); \
+    echo "deb [ signed-by=/etc/apt/keyrings/mysql.gpg ] http://repo.mysql.com/apt/ubuntu/ ${DISTRUBTION_CODENAME} mysql-${MYSQL_MAJOR_VERSION}" > /etc/apt/sources.list.d/mysql.list
+
+# the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
+# also, we set debconf keys to make APT a little quieter
+RUN export DISTRUBTION_RELEASE=$(cat /etc/lsb-release  | grep DISTRIB_RELEASE | cut -f 2 -d =); \
+    export MYSQL_PACKAGE_VERSION="${MYSQL_VERSION}-1ubuntu${DISTRUBTION_RELEASE}"; \
+    echo "MYSQL_PACKAGE_VERSION: $MYSQL_PACKAGE_VERSION"; \
+    { \
+		echo mysql-community-server mysql-community-server/data-dir select ''; \
+		echo mysql-community-server mysql-community-server/root-pass password ''; \
+		echo mysql-community-server mysql-community-server/re-root-pass password ''; \
+		echo mysql-community-server mysql-community-server/remove-test-db select false; \
+	} | debconf-set-selections \
+	&& apt-get update \
+	&& apt-get install -y \
+		mysql-community-client="${MYSQL_PACKAGE_VERSION}" \
+		mysql-community-server-core="${MYSQL_PACKAGE_VERSION}" \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
+	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	&& chmod 1777 /var/run/mysqld /var/lib/mysql
+
+VOLUME /var/lib/mysql
+
+# No config/ directory in the 8.4 upstream; configure_db passes --max_allowed_packet=256M at runtime
+COPY protocols /etc/protocols
+COPY mysql-entrypoint.sh /mysql-entrypoint.sh
+ENTRYPOINT ["/mysql-entrypoint.sh"]
+
+EXPOSE 3306 33060
+CMD ["mysqld"]

--- a/shared/dockerfiles/tas-runtime-mysql-8.4/Dockerfile
+++ b/shared/dockerfiles/tas-runtime-mysql-8.4/Dockerfile
@@ -2,6 +2,7 @@
 # Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
 # Description:
 # 2026-05-08: Add MySQL 8.4 Dockerfile for CI image build (TNZ-99882)
+# 2026-05-08: Fix apt component name - mysql-8.4 doesn't exist, use mysql-8.4-lts (TNZ-99882)
 
 # Dockerfile name: mysql-8.4
 # should be located at cloudfoundry/tas-runtime-mysql-8.4
@@ -37,7 +38,7 @@ RUN set -eux; \
 	rm -rf "$GNUPGHOME"
 
 RUN export DISTRUBTION_CODENAME=$(cat /etc/lsb-release  | grep DISTRIB_CODENAME | cut -f 2 -d =); \
-    echo "deb [ signed-by=/etc/apt/keyrings/mysql.gpg ] http://repo.mysql.com/apt/ubuntu/ ${DISTRUBTION_CODENAME} mysql-${MYSQL_MAJOR_VERSION}" > /etc/apt/sources.list.d/mysql.list
+    echo "deb [ signed-by=/etc/apt/keyrings/mysql.gpg ] http://repo.mysql.com/apt/ubuntu/ ${DISTRUBTION_CODENAME} mysql-8.4-lts" > /etc/apt/sources.list.d/mysql.list
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter

--- a/shared/dockerfiles/tas-runtime-mysql-8.4/protocols
+++ b/shared/dockerfiles/tas-runtime-mysql-8.4/protocols
@@ -1,0 +1,3 @@
+tcp 6 TCP
+udp 17 UDP
+icmp 1 UCMP

--- a/shared/pipelines/shared-docker-images.yml
+++ b/shared/pipelines/shared-docker-images.yml
@@ -1,3 +1,7 @@
+#! @AI-Generated
+#! Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+#! Description:
+#! 2026-05-08: Add MySQL 8.4 resources and build job (TNZ-99882)
 #@ load("@ytt:data", "data")
 #@ load("ytt-helpers.star", "helpers")
 
@@ -82,6 +86,16 @@ resources:
     key: #@ "tas-runtime-mysql-5.7/version-{}".format(go_version.name)
     json_key: ((gcp-wg-arp-oss-service-account/config-json))
     initial_version: #@ "{}.0".format(go_version.name)
+
+- name: #@ "mysql-8.4-image-version-{}".format(go_version.name)
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: ci-image-versions
+    key: #@ "tas-runtime-mysql-8.4/version-{}".format(go_version.name)
+    json_key: ((gcp-wg-arp-oss-service-account/config-json))
+    initial_version: #@ "{}.0".format(go_version.name)
 #@ end
 
 - name: ruby-installer-git
@@ -152,6 +166,29 @@ resources:
 #! See: https://github.com/docker-library/mysql/commit/b6c1f3997a86ad4de7ceb6b8c9b0d9f6ee15ac84
   version:
     ref: 6b2fc013b75cab7984073abdae136e39256c9935
+- name: mysql-8.4-dockerfile
+  type: git
+  icon: source-branch
+  source:
+    private_key: ((github-appruntimeplatform-bot/private-key))
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
+    branch: mysql-8.4
+    paths:
+    - shared/dockerfiles/tas-runtime-mysql-8.4/*
+- name: mysql-8.4-image
+  type: registry-image
+  icon: docker
+  source:
+    username: ((dockerhub-appruntimeplatform-username))
+    password: ((dockerhub-appruntimeplatform-password))
+    repository: cloudfoundry/tas-runtime-mysql-8.4
+- name: mysql-8.4-docker-repo
+  type: git
+  icon: source-branch
+  source:
+    private_key: ((github-appruntimeplatform-bot/private-key))
+    uri: git@github.com:docker-library/mysql.git
+    branch: master
 - name: mysql-5.7-dockerfile
   type: git
   icon: source-branch
@@ -487,6 +524,112 @@ jobs:
   - put: #@ "mysql-8.0-image-version-{}".format(go_version.name)
     params:
       file: #@ "mysql-8.0-image-version-{}/version".format(go_version.name)
+- name: #@ "build-mysql-8.4-image-{}".format(go_version.name)
+  plan:
+  - in_parallel:
+    - get: mysql-8.4-dockerfile
+      trigger: true
+    - get: #@ "build-image-version-{}".format(go_version.name)
+      trigger: true
+      passed:
+      - #@ "build-build-image-{}".format(go_version.name)
+    - get: go-version
+      passed:
+      - #@ "build-build-image-{}".format(go_version.name)
+    - get: ci
+      passed:
+      - #@ "build-build-image-{}".format(go_version.name)
+    - get: #@ "mysql-8.4-image-version-{}".format(go_version.name)
+      params:
+        bump: patch
+    - get: mysql-8.4-docker-repo
+      trigger: true
+    - get: build-image
+  - in_parallel:
+    - task: collect-docker-files
+      file: ci/shared/tasks/combine-assets/linux.yml
+      image: build-image
+      input_mapping:
+        input-01: mysql-8.4-dockerfile
+        input-02: mysql-8.4-docker-repo
+      output_mapping:
+        combined-assets: dockerfile-out
+      params:
+        COPY_ACTIONS: |
+          {input-01/shared/dockerfiles/tas-runtime-mysql-8.4/*,combined-assets}
+          {input-02/8.4/docker-entrypoint.sh,combined-assets/mysql-entrypoint.sh}
+    - task: print-go-version-tag
+      image: build-image
+      file: ci/shared/tasks/build-golang-version-tags/linux.yml
+      params:
+        GO_MAJOR_MINOR_VERSION: #@ "{}".format(go_version.name)
+    - task: write-build-args
+      image: build-image
+      params:
+        MYSQL_MAJOR_VERSION: "8.4"
+      config:
+        platform: linux
+        params:
+          MYSQL_MAJOR_VERSION: null
+        inputs:
+        - name: #@ "build-image-version-{}".format(go_version.name)
+        - name: mysql-8.4-docker-repo
+        outputs:
+        - name: dockerfile-build-args
+        run:
+          path: /bin/bash
+          args:
+          - -c
+          - |
+            set -eux
+            mkdir -p dockerfile-build-args
+
+            export build_uri="cloudfoundry/tas-runtime-build:$(cat build-image-version-*/version)"
+            export mysql_major_version="${MYSQL_MAJOR_VERSION:-}"
+            export mysql_version=$(jq -r ".[\"${MYSQL_MAJOR_VERSION}\"].version" mysql-8.4-docker-repo/versions.json)
+
+            cat <<EOF > dockerfile-build-args/build_args
+            BUILD_URI=$build_uri
+            MYSQL_MAJOR_VERSION=$mysql_major_version
+            MYSQL_VERSION=$mysql_version
+            EOF
+
+            cat dockerfile-build-args/build_args
+  - task: build-mysql-8.4-image
+    privileged: true
+    config:
+      platform: linux
+      run:
+        path: build
+      params:
+        BUILD_ARGS_FILE: dockerfile-build-args/build_args
+        CONTEXT: dockerfile-out
+        OUTPUT_OCI: true
+        #! no arm64 packages for mysql-community could be found, so not multi-arch building this either
+        IMAGE_PLATFORM: linux/amd64
+      inputs:
+        - name: dockerfile-out
+        - name: dockerfile-build-args
+      outputs:
+        - name: image
+      image_resource:
+        type: registry-image
+        source:
+          repository: us-central1-docker.pkg.dev/app-runtime-platform-wg/dockerhub-mirror/concourse/oci-build-task
+          username: _json_key
+          password: ((gcp-arp-artifact-registry-service-account-token))
+  - load_var: mysql84-image-version
+    file: #@ "mysql-8.4-image-version-{}/version".format(go_version.name)
+    format: raw
+  - put: mysql-8.4-image
+    params:
+      image: image/image
+      version: ((.:mysql84-image-version))
+      additional_tags: tag/tag
+      bump_aliases: true
+  - put: #@ "mysql-8.4-image-version-{}".format(go_version.name)
+    params:
+      file: #@ "mysql-8.4-image-version-{}/version".format(go_version.name)
 - name: #@ "build-mysql-5.7-image-{}".format(go_version.name)
   plan:
   - in_parallel:

--- a/wg-arp-networking-modules/index.yml
+++ b/wg-arp-networking-modules/index.yml
@@ -8,6 +8,8 @@ db_flavors:
   value: postgres
 - image: mysql-8.0
   value: mysql
+- image: mysql-8.4
+  value: mysql
 - image: mysql-5.7
   value: mysql
 


### PR DESCRIPTION
MySQL 8.0 reached EOL in April 2026. This adds parallel MySQL 8.4 support to the shared-docker-images pipeline: new Dockerfile under shared/dockerfiles/tas-runtime-mysql-8.4/ (no config/ copy needed as 8.4 upstream has no config/ dir), three new pipeline resources (dockerfile, registry-image, docker-repo), a semver version resource inside the go_version loop, and a new build-mysql-8.4-image-{go_version} job modeled exactly on the 8.0 equivalent.
Note: cloudfoundry/tas-runtime-mysql-8.4 DockerHub repo must be created manually before the pipeline will succeed.

ai-assisted=yes
TNZ-99882